### PR TITLE
Auto compute events

### DIFF
--- a/aisc_website/app/events/page.tsx
+++ b/aisc_website/app/events/page.tsx
@@ -14,6 +14,10 @@ export default function EventsPage() {
     const times = split[1].split(" ");
     const startTime = new Date(split[0]+" "+year+" "+times[0]+" "+times[2].slice(-2)+" PST");
     const endTime = new Date(split[0]+" "+year+" "+times[2].slice(0,-2)+" "+times[2].slice(-2)+" PST");
+    // Edge case where startTime is supposed to be AM (Eg: "..| 11:00 - 2:30PM PST")
+    if (startTime > endTime) {
+      startTime.setHours(startTime.getHours() - 12);
+    }
     return [startTime, endTime]
   }
 

--- a/aisc_website/app/events/page.tsx
+++ b/aisc_website/app/events/page.tsx
@@ -29,7 +29,7 @@ export default function EventsPage() {
   }
 
   function icsFileContent(
-    event: { title: string; location: string; date: string },
+    event: { status: string; title: string; location: string; date: string },
     startTime: Date,
     endTime: Date
   ) {
@@ -55,22 +55,20 @@ export default function EventsPage() {
   const now = new Date();
   const processedEvents = events.map((event) => {
       const [startTime, endTime] = dateParser(event.date);
-      let status: "Past" | "Upcoming" | "Happening";
       let icsDownloadUrl = "";
 
       if (endTime < now) {
-        status = "Past";
+        event.status = "Past";
       } else if (now < startTime) {
-        status = "Upcoming";
+        event.status = "Upcoming";
         const icsContent = icsFileContent(event, startTime, endTime);
         icsDownloadUrl = `data:text/calendar;charset=utf-8,${encodeURIComponent(icsContent)}`;
       } else {
-        status = "Happening";
+        event.status = "Happening";
       }
 
       return {
         ...event,
-        status,
         icsDownloadUrl,
         startTime,
       };

--- a/aisc_website/app/events/page.tsx
+++ b/aisc_website/app/events/page.tsx
@@ -7,10 +7,75 @@ import { useState, useEffect, Fragment } from "react";
 
 export default function EventsPage() {
   const [openCategory, setOpenCategory] = useState("");
+  const year = new Date().getFullYear();
+  function dateParser(date: string) {
+    // Example: "date": "Thursday, January 8 | 11:00 - 2:30PM PST"
+    const split = date.split(" | ");
+    const times = split[1].split(" ");
+    const startTime = new Date(split[0]+" "+year+" "+times[0]+" "+times[2].slice(-2)+" PST");
+    const endTime = new Date(split[0]+" "+year+" "+times[2].slice(0,-2)+" "+times[2].slice(-2)+" PST");
+    return [startTime, endTime]
+  }
+
+  function toICSDateTime(date: Date) {
+    return date
+      .toISOString()
+      .replace(/[-:]/g, "")
+      .replace(/\.\d{3}Z$/, "Z");
+  }
+
+  function icsFileContent(
+    event: { title: string; location: string; date: string },
+    startTime: Date,
+    endTime: Date
+  ) {
+
+    const icsContent = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//AISC//AISC Events//EN',
+      'BEGIN:VEVENT',
+      'UID:' + encodeURIComponent(`${event.title}-${event.date}`),
+      'DTSTAMP:' + toICSDateTime(new Date()),
+      'DTSTART:' + toICSDateTime(startTime),
+      'DTEND:' + toICSDateTime(endTime),
+      'SUMMARY:' + event.title,
+      'LOCATION:' + event.location,
+      'END:VEVENT',
+      'END:VCALENDAR'
+    ];
+
+    return icsContent.join("\r\n");
+  }
+
+  const now = new Date();
+  const processedEvents = events.map((event) => {
+      const [startTime, endTime] = dateParser(event.date);
+      let status: "Past" | "Upcoming" | "Happening";
+      let icsDownloadUrl = "";
+
+      if (endTime < now) {
+        status = "Past";
+      } else if (now < startTime) {
+        status = "Upcoming";
+        const icsContent = icsFileContent(event, startTime, endTime);
+        icsDownloadUrl = `data:text/calendar;charset=utf-8,${encodeURIComponent(icsContent)}`;
+      } else {
+        status = "Happening";
+      }
+
+      return {
+        ...event,
+        status,
+        icsDownloadUrl,
+        startTime,
+      };
+  }).sort((a, b) => a.startTime.getTime() - b.startTime.getTime());;
+
   useEffect(() => {
     const priorities = ["Happening", "Upcoming", "Past"];
     for (const category of priorities) {
-      if (events.some((event) => event.status === category)) {
+      if (processedEvents.some((event) => event.status === category)) {
         setOpenCategory(category);
         break;
       }
@@ -41,10 +106,11 @@ export default function EventsPage() {
       </section>
       <section className="space-y-24 mt-12">
         {["Happening", "Upcoming", "Past"].map((category) => {
-          const filteredEvents = events.filter(
+          const filteredEvents = processedEvents.filter(
             (event) => event.status === category
-          ).slice(0, 4);
-          if (filteredEvents.length === 0) return null;
+          );
+          const orderedEvents = (category === "Past" ? filteredEvents.reverse() : filteredEvents).slice(0, 4); // Show recent events first in past events
+          if (orderedEvents.length === 0) return null;
 
           return (
             <Fragment key={category}>
@@ -62,7 +128,7 @@ export default function EventsPage() {
                 <div
                   className={`transition-all duration-500 overflow-hidden ${openCategory !== category && "max-h-0 opacity-0"}`}
                 >
-                  {filteredEvents.map((event, index) => {
+                  {orderedEvents.map((event, index) => {
                     const isEven = index % 2 === 0;
                     return (
                       <div
@@ -90,6 +156,15 @@ export default function EventsPage() {
                           <p className="mb-4 text-lg md:text-xl dark:text-white/70 font-[var(--font-bai-jamjuree)]">
                             {event.location}
                           </p>
+                          {event.icsDownloadUrl && (
+                            <a
+                              href={event.icsDownloadUrl}
+                              download={`${event.title.replace(/\s+/g, "-").toLowerCase()}.ics`}
+                              className="inline-block text-sm md:text-base font-semibold text-[#00add4] dark:text-[#00BCD4] hover:underline font-[var(--font-bai-jamjuree)]"
+                            >
+                              Add to Calendar (.ics)
+                            </a>
+                          )}
                         </div>
                         <div className={`flex-1 w-full max-w-md group overflow-hidden ${event.image === null && "hidden"}`}>
                           <Image

--- a/aisc_website/lib/events.json
+++ b/aisc_website/lib/events.json
@@ -1,5 +1,6 @@
 [
   {
+    "status": "Past",
     "image": "DataVisualizationsWorkshop.png",
     "title": "Technical Workshop: Data Visualizations (Matplotlib & Seaborn)",
     "date": "Wednesday, February 18 | 5:00 - 6:00PM PST",
@@ -8,6 +9,7 @@
   },
 
   {
+    "status": "Past",
     "image": "AISC_-_Introduction_to_Kaggle_Competitions_Worshop.png",
     "title": "Technical Workshop: Getting Started with Kaggle Competitions",
     "date": "Thursday, February 19 | 5:00 - 6:00PM PST",
@@ -16,6 +18,7 @@
   },
 
   {
+    "status": "Past",
     "image": "envision.jpg",
     "title": "Envision 2026 Showcase",
     "date": "Saturday, February 21 | 1:00 - 2:00PM PST",
@@ -24,6 +27,7 @@
   },
 
   {
+    "status": "Upcoming",
     "image": "SonataSimonaitis-Boyd.png",
     "title": "Guest Speaker Sonata Simonaitis-Boyd",
     "date": "Thursday, February 26 | 5:00 - 6:00PM PST",
@@ -32,6 +36,7 @@
   },
 
   {
+    "status": "Past",
     "image": "EngineersOnTheGreenFlyer.png",
     "title": "Engineers on the Green",
     "date": "Thursday, January 8 | 11:00 - 2:30PM PST",

--- a/aisc_website/lib/events.json
+++ b/aisc_website/lib/events.json
@@ -1,6 +1,5 @@
 [
   {
-    "status": "Upcoming",
     "image": "DataVisualizationsWorkshop.png",
     "title": "Technical Workshop: Data Visualizations (Matplotlib & Seaborn)",
     "date": "Wednesday, February 18 | 5:00 - 6:00PM PST",
@@ -9,7 +8,6 @@
   },
 
   {
-    "status": "Upcoming",
     "image": "AISC_-_Introduction_to_Kaggle_Competitions_Worshop.png",
     "title": "Technical Workshop: Getting Started with Kaggle Competitions",
     "date": "Thursday, February 19 | 5:00 - 6:00PM PST",
@@ -18,7 +16,6 @@
   },
 
   {
-    "status": "Upcoming",
     "image": "envision.jpg",
     "title": "Envision 2026 Showcase",
     "date": "Saturday, February 21 | 1:00 - 2:00PM PST",
@@ -27,7 +24,6 @@
   },
 
   {
-    "status": "Upcoming",
     "image": "SonataSimonaitis-Boyd.png",
     "title": "Guest Speaker Sonata Simonaitis-Boyd",
     "date": "Thursday, February 26 | 5:00 - 6:00PM PST",
@@ -36,7 +32,6 @@
   },
 
   {
-    "status": "Past",
     "image": "EngineersOnTheGreenFlyer.png",
     "title": "Engineers on the Green",
     "date": "Thursday, January 8 | 11:00 - 2:30PM PST",


### PR DESCRIPTION
Implemented downloadable .ics file link for upcoming events and also implemented reverse ordering for past events(recent events are shown first) and chronological ordering for happening and upcoming events.

There's no need to add status when updating events.json now anymore. 